### PR TITLE
feat: add a 3s delay before closing the app

### DIFF
--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -14,11 +14,12 @@ import path from 'path';
 import { app, BrowserWindow, shell, ipcMain } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
-import { createWriteStream, createReadStream, readdirSync, unlink } from 'fs';
+import { createWriteStream, createReadStream } from 'fs';
 import MenuBuilder from './menu';
 import GdriveClient from './client/gdrive';
 import Library from './library';
 import { decryptAes256Cbc } from './utils/cryptoUtils';
+import { purgeDecryptedFiles } from './utils/fileUtils';
 
 export default class AppUpdater {
   constructor() {
@@ -59,22 +60,12 @@ const installExtensions = async () => {
     .catch(console.log);
 };
 
-const purgeDecryptedFiles = () => {
-  console.log('Purging decrypted files...');
-  const dir = library.config.local.path;
-  const filenames = readdirSync(dir).filter((f) => !f.endsWith('.aes'));
-  return Promise.all(
-    filenames.map(
-      (filename) =>
-        new Promise((resolve) => {
-          unlink(path.join(dir, filename), (err) => {
-            if (err) throw err;
-            console.log('Deleted: ', filename);
-            resolve(filename);
-          });
-        })
-    )
-  );
+const appQuitWrapper = () => {
+  // Respect the OSX convention of having the application in memory even
+  // after all windows have been closed
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
 };
 
 const createWindow = async () => {
@@ -143,12 +134,14 @@ const createWindow = async () => {
  */
 
 app.on('window-all-closed', () => {
-  // Respect the OSX convention of having the application in memory even
-  // after all windows have been closed
-  if (process.platform !== 'darwin') {
-    // eslint-disable-next-line promise/catch-or-return
-    purgeDecryptedFiles().finally(app.quit);
-  }
+  // Wait 3 seconds for files to close gracefully, delete the files and then call .appQuitWrapper().
+  setTimeout(
+    () =>
+      purgeDecryptedFiles(library.config.local.path)
+        .then((results) => results.forEach((result) => console.log(result)))
+        .finally(appQuitWrapper),
+    3000
+  );
 });
 
 app.whenReady().then(createWindow).catch(console.log);

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -1,3 +1,5 @@
+import { unlink, readdirSync } from 'fs';
+
 const path = require('path');
 
 const SUPPORTED_IN_APP_FILE_TYPE = ['mp4'];
@@ -13,6 +15,21 @@ export const getExtnameWithoutDotOrDefault = (
   return ext;
 };
 
-export const isSupportedInAppFileType = (ext) => {
+export const isSupportedInAppFileType = (ext: string) => {
   return SUPPORTED_IN_APP_FILE_TYPE.includes(ext);
+};
+
+export const purgeDecryptedFiles = (dir: string) => {
+  const filenames = readdirSync(dir).filter((f) => !f.endsWith('.aes'));
+  return Promise.allSettled(
+    filenames.map((filename) => {
+      const fullPath = path.join(dir, filename);
+      return new Promise((resolve, reject) => {
+        unlink(fullPath, (error) => {
+          if (error) reject(error);
+          resolve(filename);
+        });
+      });
+    })
+  );
 };


### PR DESCRIPTION
On app close:

Wait 3 seconds for the decrypted files to close gracefully, delete the files and then call `.appQuitWrapper()`.

The 3 second delay reduces the risk of seeing `errno` -4082.