### PR TITLE
feat: use tmpLocalPath

### DIFF
--- a/src/client/gdrive.ts
+++ b/src/client/gdrive.ts
@@ -1,3 +1,5 @@
+import { renameSync } from "fs";
+
 /* eslint-disable import/prefer-default-export */
 const fs = require('fs');
 const { google } = require('googleapis');
@@ -72,7 +74,8 @@ class GdriveClient {
     );
 
     return new Promise((resolve, reject) => {
-      const dest = fs.createWriteStream(localPath);
+      const tmpLocalPath = `${localPath}.download`;
+      const dest = fs.createWriteStream(tmpLocalPath);
       const { data } = res;
       let downloadedBytes = 0;
 
@@ -90,8 +93,11 @@ class GdriveClient {
           }
         });
         data.on('finish', () => {
-          // dest.close();
-          resolve(localPath);
+          setTimeout(() => {
+            // wait 1.5s before removing the .download extension so the file pointer is properly closed, etc.
+            renameSync(tmpLocalPath, localPath);
+            resolve(localPath);
+          }, 1500);
         });
         data.pipe(dest);
       } catch (error) {

--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -134,13 +134,13 @@ const createWindow = async () => {
  */
 
 app.on('window-all-closed', () => {
-  // Wait 3 seconds for files to close gracefully, delete the files and then call .appQuitWrapper().
+  // Wait 1.5 seconds for files to close gracefully, delete the files and then call .appQuitWrapper().
   setTimeout(
     () =>
       purgeDecryptedFiles(library.config.local.path)
         .then((results) => results.forEach((result) => console.log(result)))
         .finally(appQuitWrapper),
-    3000
+    1500
   );
 });
 


### PR DESCRIPTION
In Corganize, `fs.existsSync(encryptedPath)` is a common way to tell the status of a file. If the local encrypted path exists, then the file is considered 'downloaded' and is now ready for decryption.

The downside of this approach is that the incomplete files can be recognized incorrectly as 'downloaded' and cause issues in the subsequent processes.

This PR is an attempt to fix that problem by initially piping the file content to `${localPath}.download` and then renaming the file as `localPath` after the fact.

Bonus change: 1.5s seems like enough time for file pointers to close. so using the same 1.5s timeout in the exit flow.