### PR TITLE
fix: quit gracefully even when 'library' is null

### DIFF
--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -134,9 +134,14 @@ const createWindow = async () => {
  */
 
 app.on('window-all-closed', () => {
-  // Wait 1.5 seconds for files to close gracefully, delete the files and then call .appQuitWrapper().
+  if (!library) {
+    appQuitWrapper();
+    return;
+  }
+
   setTimeout(
     () =>
+      // Wait 1.5 seconds for files to close gracefully, delete the files and then call .appQuitWrapper().
       purgeDecryptedFiles(library.config.local.path)
         .then((results) => results.forEach((result) => console.log(result)))
         .finally(appQuitWrapper),


### PR DESCRIPTION
The app attempts to clean up the decrypted files upon app close but it is possible for user to close the app without selecting a browser (ie. launch the app and close immediately).

This PR adds a little null check to allow graceful shutdown.