### PR TITLE
feat: detect mime type after decrypting

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,6 +252,7 @@
     "electron-debug": "^3.1.0",
     "electron-log": "^4.2.4",
     "electron-updater": "^4.3.4",
+    "file-type": "^16.1.0",
     "googleapis": "^66.0.0",
     "history": "^5.0.0",
     "node-aescrypt": "1.0.8",

--- a/src/components/DownloadCenter.tsx
+++ b/src/components/DownloadCenter.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable promise/always-return */
+/* eslint-disable promise/catch-or-return */
 import { ipcRenderer } from 'electron';
 import React, { useEffect, useState } from 'react';
 

--- a/src/components/FileActions.tsx
+++ b/src/components/FileActions.tsx
@@ -5,10 +5,6 @@ import { existsSync } from 'fs';
 import React from 'react';
 import { copyTextToClipboard } from '../utils/clipboardUtils';
 
-import {
-  getExtnameWithoutDotOrDefault,
-  isSupportedInAppFileType,
-} from '../utils/fileUtils';
 import Button from './Button';
 import DownloadProgressBar from './DownloadProgressBar';
 import FileViewModal from './FileViewModal';
@@ -22,25 +18,18 @@ const FileActions = ({
   file,
   isClipboarded,
   encryptedPath,
-  defaultExtname,
   updateLocalFileStatus,
   setClipboardedFileId,
   setFileViewModal,
   localFileStatus,
   aespassword,
 }) => {
-  const { fileid, sourceurl, filename, locationref, size } = file;
-  const ext = getExtnameWithoutDotOrDefault(filename, defaultExtname);
+  const { fileid, sourceurl, locationref } = file;
 
   const openInApp = () => {
-    if (!isSupportedInAppFileType(ext)) {
-      throw new Error(`Unsupported ext: ${ext}`);
-    }
-
     setFileViewModal(
       <FileViewModal
         file={file}
-        ext={ext}
         onClose={() => setFileViewModal(null)}
         encryptedPath={encryptedPath}
         aespassword={aespassword}

--- a/src/components/FileViewModal.tsx
+++ b/src/components/FileViewModal.tsx
@@ -9,6 +9,8 @@ import Button from './Button';
 
 import './FileViewModal.scss';
 
+const FileType = require('file-type');
+
 const getFileManagerAppName = () => {
   switch (os.platform()) {
     case 'win32':
@@ -21,9 +23,9 @@ const getFileManagerAppName = () => {
   }
 };
 
-const FileViewModal = ({ file, ext, onClose, encryptedPath, aespassword }) => {
+const FileViewModal = ({ file, onClose, encryptedPath, aespassword }) => {
   const { filename } = file;
-  const decryptedPath = `${encryptedPath}.${ext}`;
+  const decryptedPath = `${encryptedPath}.dec`;
   const [content, setContent] = useState(null);
 
   useEffect(() => {
@@ -40,14 +42,15 @@ const FileViewModal = ({ file, ext, onClose, encryptedPath, aespassword }) => {
       }
       // eslint-disable-next-line promise/catch-or-return
       decryptPromise
-        .then(() => {
-          switch (ext) {
-            case 'mp4':
+        .then(() => FileType.fromFile(decryptedPath))
+        .then(({ mime }) => {
+          switch (mime) {
+            case 'video/mp4':
               return <ReactPlayer url={decryptedPath} controls muted playing />;
-            case 'txt':
+            case 'text/plain':
               return <pre>{readFileSync(decryptedPath)}</pre>;
             default:
-              return 'Unsupported File Type';
+              return `Unsupported: ${mime}`;
           }
         })
         .then((value) => setContent(value));

--- a/src/components/TableView.tsx
+++ b/src/components/TableView.tsx
@@ -85,7 +85,6 @@ const TableView = ({ library }) => {
         encryptedPath={library.getEncryptedPath(fileid)}
         localFileStatus={localFileStatusMap[fileid]}
         aespassword={library.config.local.aes.password}
-        defaultExtname={library.config.local.defaultExtname}
         updateLocalFileStatus={updateLocalFileStatus}
         setClipboardedFileId={setClipboardedFileId}
         setFileViewModal={setFileViewModal}

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-react-boilerplate",
   "productName": "electron-react-boilerplate",
-  "version": "2.0.1",
+  "version": "0.1.0",
   "description": "Electron application boilerplate based on React, React Router, Webpack, React Hot Loader for rapid application development",
   "main": "./main.prod.js",
   "author": {

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -2,23 +2,6 @@ import { unlink, readdirSync } from 'fs';
 
 const path = require('path');
 
-const SUPPORTED_IN_APP_FILE_TYPE = ['mp4'];
-
-export const getExtnameWithoutDotOrDefault = (
-  filename: string,
-  defaultExtname: string
-) => {
-  const ext = (path.extname(filename) || '').replace('.', '');
-  if (!SUPPORTED_IN_APP_FILE_TYPE.includes(ext)) {
-    return defaultExtname;
-  }
-  return ext;
-};
-
-export const isSupportedInAppFileType = (ext: string) => {
-  return SUPPORTED_IN_APP_FILE_TYPE.includes(ext);
-};
-
 export const purgeDecryptedFiles = (dir: string) => {
   const filenames = readdirSync(dir).filter((f) => !f.endsWith('.aes'));
   return Promise.allSettled(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1468,6 +1468,11 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
 
+"@tokenizer/token@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.1.1.tgz#f0d92c12f87079ddfd1b29f614758b9696bc29e3"
+  integrity sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w==
+
 "@types/aria-query@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
@@ -1728,6 +1733,14 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
+
+"@types/readable-stream@^2.3.9":
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/@types/readable-stream/-/readable-stream-2.3.9.tgz#40a8349e6ace3afd2dd1b6d8e9b02945de4566a9"
+  integrity sha512-sqsgQqFT7HmQz/V5jH1O0fvQQnXAJO46Gg9LRO/JPfjmVmGUlcx831TZZO3Y3HtWhIkzf3kTsNT0Z0kzIhIvZw==
+  dependencies:
+    "@types/node" "*"
+    safe-buffer "*"
 
 "@types/responselike@*", "@types/responselike@^1.0.0":
   version "1.0.0"
@@ -5348,6 +5361,16 @@ file-loader@^6.0.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
+file-type@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-16.1.0.tgz#1c8a4458b2103e07d2b49ae7f76384abafe86529"
+  integrity sha512-G4Klqf6tuprtG0pC4r9kni4Wv8XhAAsfHphVqsQGA+YiOlPAO40BZduDqKfv0RFsu9q9ZbFObWfwszY/NqhEZw==
+  dependencies:
+    readable-web-to-node-stream "^3.0.0"
+    strtok3 "^6.0.3"
+    token-types "^2.0.0"
+    typedarray-to-buffer "^3.1.5"
+
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
@@ -6278,7 +6301,7 @@ identity-obj-proxy@^3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ieee754@^1.1.4:
+ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -9004,6 +9027,11 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+peek-readable@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-3.1.2.tgz#5edab75fa130e21ca290c444892faa0c208a78f0"
+  integrity sha512-aJrwgM+VdX8VoIz5EE1Mg56a3g3s93wsV0bvCDQgvFNfnTr++Ij5eQWIz9VP8QyuL9+jFHR7iNPalrc1GvK2WA==
+
 pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
@@ -9871,6 +9899,14 @@ readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.6.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+readable-web-to-node-stream@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.1.tgz#3f619b1bc5dd73a4cfe5c5f9b4f6faba55dff845"
+  integrity sha512-4zDC6CvjUyusN7V0QLsXVB7pJCD9+vtrM9bYDRv6uBQ+SKfx36rp5AFNPRgh9auKRul/a1iFZJYXcCbwRL+SaA==
+  dependencies:
+    "@types/readable-stream" "^2.3.9"
+    readable-stream "^3.6.0"
+
 readdirp@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
@@ -10240,15 +10276,15 @@ rxjs@^6.5.2, rxjs@^6.6.3:
   dependencies:
     tslib "^1.9.0"
 
+safe-buffer@*, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -11057,6 +11093,15 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
+strtok3@^6.0.3:
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.0.7.tgz#f8e57027b96b4dfb76fc7361f34b283c5933a832"
+  integrity sha512-D9O/aefUl/JLjfA//GQ0JX+nJMHiB5mkUQWWdjMnK+mB6PpzxDpnpajkDxuR18zYHvfXV44kDYrhT4UAeHRceg==
+  dependencies:
+    "@tokenizer/token" "^0.1.1"
+    "@types/debug" "^4.1.5"
+    peek-readable "^3.1.2"
+
 style-loader@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-2.0.0.tgz#9669602fd4690740eaaec137799a03addbbc393c"
@@ -11343,6 +11388,14 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+token-types@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/token-types/-/token-types-2.1.0.tgz#eba77672bcbf7a769e3f9784e66843583c6cd09f"
+  integrity sha512-1qf3CWuVNJkThHwD0E4VWJXwn3COAkEaOmqVtqHzHSznTHMUbw+3v8Teag4MBvWyGYK5Rti7aIrH06XoKpNxQg==
+  dependencies:
+    "@tokenizer/token" "^0.1.1"
+    ieee754 "^1.1.13"
 
 tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   version "2.5.0"


### PR DESCRIPTION
Use `file-type` to detect the mime type of the decrypted file, rather than trying to infer it from the file name.