### PR TITLE
feat: use dateactivated like a boolean in the table

### DIFF
--- a/src/cellFormatter.tsx
+++ b/src/cellFormatter.tsx
@@ -24,6 +24,7 @@ export default function format(props) {
         .trim();
       return relativeString;
     }
+    case 'dateactivated':
     case 'ispublic':
     case 'isactive': {
       const classNames = `${String(!!value)} icon`;

--- a/src/components/TableView.scss
+++ b/src/components/TableView.scss
@@ -30,7 +30,7 @@
             width: 80px;
           }
 
-          &.isactive {
+          &.dateactivated {
             width: 80px;
           }
 
@@ -91,7 +91,7 @@
           background-image: url('../../assets/lock-svgrepo-com.svg');
         }
 
-        .isactive > .true {
+        .dateactivated > .true {
           background-image: url('../../assets/iconmonstr-check-mark.svg');
         }
 

--- a/src/components/TableView.tsx
+++ b/src/components/TableView.tsx
@@ -12,6 +12,7 @@ import {
   useSortBy,
   usePagination,
   useGlobalFilter,
+  useColumnOrder,
 } from 'react-table';
 import format from '../cellformatter';
 import PageControl from './PageControl';
@@ -26,16 +27,16 @@ import FileActions from './FileActions';
 import DownloadCenter from './DownloadCenter';
 
 const regularColumns = [
-  'isactive',
   'ispublic',
   'storageservice',
   'size',
   'lastupdated',
   'sourceurl',
-].map((accessor) => {
+].map((id) => {
   return {
-    accessor,
-    Header: accessor,
+    id,
+    accessor: id,
+    Header: id,
     Cell: format,
   };
 });
@@ -97,14 +98,20 @@ const TableView = ({ library }) => {
     () => {
       const computedColumns = [
         {
+          id: 'filename',
           accessor: 'filename',
           Header: 'filename',
-          id: 'filename',
           Cell: renderFilename,
         },
         {
           id: 'actions',
           Cell: renderActions,
+        },
+        {
+          id: 'dateactivated',
+          accessor: 'dateactivated',
+          Header: 'act',
+          Cell: format,
         },
       ];
       return regularColumns.concat(computedColumns);
@@ -117,10 +124,11 @@ const TableView = ({ library }) => {
     {
       columns,
       data,
-      initialState: { hiddenColumns },
+      initialState: { hiddenColumns, columnOrder: ['dateactivated'] },
     },
     useGlobalFilter,
     useSortBy,
+    useColumnOrder,
     usePagination
   );
 


### PR DESCRIPTION
react-table's sorting logic isn't straightforward for boolean fields.

Since `dateactivated` fields can be used to derive the same boolean value, and is easier to sort, this is what will be used in the table going forward.