### PR TITLE
refactor: move download listener

### DIFF
--- a/src/components/DownloadCenter.tsx
+++ b/src/components/DownloadCenter.tsx
@@ -1,13 +1,30 @@
 /* eslint-disable promise/always-return */
 /* eslint-disable promise/catch-or-return */
-import React from 'react';
+import { ipcRenderer } from 'electron';
+import React, { useEffect, useState } from 'react';
 
 import './DownloadCenter.scss';
 
-const DownloadCenter = ({ downloadProgress }) => {
-  const activeDownloadCount = Object.values(downloadProgress).filter(
-    (value) => value < 100
-  ).length;
+const downloads = {};
+
+const DownloadCenter = () => {
+  const [activeDownloadCount, setActiveDownloadCount] = useState(0);
+
+  useEffect(() => {
+    const downloadListener = (_event, { fileid, percentage, isInitial }) => {
+      if (isInitial || percentage > downloads[fileid]) {
+        downloads[fileid] = percentage;
+        setActiveDownloadCount(
+          Object.values(downloads).filter((value) => value < 100).length
+        );
+      }
+    };
+    ipcRenderer.on('downloadProgress', downloadListener);
+
+    return () => {
+      ipcRenderer.removeListener('downloadProgress', downloadListener);
+    };
+  });
 
   return (
     <div className={`download-center ${activeDownloadCount === 0 && 'zero'}`}>

--- a/src/components/FileActions.tsx
+++ b/src/components/FileActions.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable react/prop-types */
 import { ipcRenderer } from 'electron';
 import { existsSync } from 'fs';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import Button from './Button';
 import FileView from './FileView';
@@ -13,9 +13,24 @@ const FileActions = ({
   aespassword,
   setFullscreenComponent,
   updateFile,
-  downloadPercentage,
 }) => {
   const { fileid, locationref, filename, mimetype } = file;
+  const [download] = useState({ percentage: null });
+  const [, setRerenderTimestamp] = useState(null);
+
+  useEffect(() => {
+    const channel = `download${fileid}`;
+    const downloadListener = (_event, { percentage, isInitial }) => {
+      if (isInitial || percentage > download.percentage) {
+        download.percentage = percentage;
+        setRerenderTimestamp(Date.now());
+      }
+    };
+    ipcRenderer.on(channel, downloadListener);
+    return () => {
+      ipcRenderer.removeListener(channel, downloadListener);
+    };
+  });
 
   const openInApp = () => {
     const onDetectMimetype = (detected: string) => {
@@ -37,8 +52,8 @@ const FileActions = ({
   };
 
   let actionButton = null;
-  if (downloadPercentage < 100) {
-    actionButton = <Button disabled>{downloadPercentage}%</Button>;
+  if (download.percentage !== null && download.percentage < 100) {
+    actionButton = <Button disabled>{download.percentage}%</Button>;
   } else if (existsSync(encryptedPath)) {
     actionButton = <Button onClick={openInApp}>Open</Button>;
   } else if (locationref) {

--- a/src/components/MainView.tsx
+++ b/src/components/MainView.tsx
@@ -13,7 +13,6 @@ import {
   useGlobalFilter,
   useColumnOrder,
 } from 'react-table';
-import { ipcRenderer } from 'electron';
 import format from '../cellformatter';
 
 import './MainView.scss';
@@ -42,8 +41,6 @@ const regularColumns = [
   };
 });
 const hiddenColumns = ['sourceurl', 'storageservice', 'ispublic', 'mimetype'];
-
-const downloadProgress = {};
 
 // MainView.state.files will grow in size as the data is retrieved via server side pagination.
 // Unfortunately, updating a state value within a React component can be slow at times; causing some chunks to be skipped, etc.
@@ -95,7 +92,6 @@ const MainView = ({ library, showAlert }) => {
         aespassword={library.config.local.aes.password}
         setFullscreenComponent={setFullscreenComponent}
         updateFile={updateFile}
-        downloadPercentage={downloadProgress[fileid]}
       />
     );
   };
@@ -151,17 +147,6 @@ const MainView = ({ library, showAlert }) => {
 
   useEffect(() => {
     if (!files) {
-      ipcRenderer.removeAllListeners('downloadProgress');
-      ipcRenderer.on(
-        'downloadProgress',
-        (_event, { fileid, percentage, isInitial }) => {
-          if (isInitial || percentage > downloadProgress[fileid]) {
-            downloadProgress[fileid] = percentage;
-            setRerenderTimestamp(Date.now());
-          }
-        }
-      );
-
       const progressCallback = (moreFiles) => {
         filesRenderBuffer = filesRenderBuffer.concat(moreFiles);
         setFiles(filesRenderBuffer);
@@ -210,7 +195,7 @@ const MainView = ({ library, showAlert }) => {
   return (
     <>
       <GlobalFilter {...tableInstance} />
-      <DownloadCenter downloadProgress={downloadProgress} />
+      <DownloadCenter />
       <TableView tableInstance={tableInstance} />
     </>
   );

--- a/src/main.dev.handlers.ts
+++ b/src/main.dev.handlers.ts
@@ -8,22 +8,21 @@ export const handleDownload = (mainWindow, library, gdriveClient) => {
   ipcMain.handle(
     'download',
     async (_event, { fileid, storageservice, locationref, size }) => {
+      const respond = (percentage: number, isInitial = false) => {
+        const payload = { fileid, percentage, isInitial };
+        mainWindow?.webContents.send('downloadProgress', payload);
+        mainWindow?.webContents.send(`download${fileid}`, payload);
+      };
+
       console.log(`Download event received: ${fileid}`);
       const localPath = library.getEncryptedPath(fileid);
       switch (storageservice) {
         case 'gdrive': {
-          mainWindow?.webContents.send('downloadProgress', {
-            fileid,
-            percentage: 0,
-            isInitial: true,
-          });
+          respond(0, true);
           console.log(`Download started: ${fileid}`);
           const callback = ({ downloadedBytes }) => {
             const percentage = Math.floor((downloadedBytes * 100) / size);
-            mainWindow?.webContents.send('downloadProgress', {
-              fileid,
-              percentage,
-            });
+            respond(percentage);
             if (percentage === 100) {
               console.log(`Download finished: ${fileid}`);
             }


### PR DESCRIPTION
The download listener was placed in the `MainView` component, causing the component to re-render way too fast / too many times.

This made the subcomponents flash rapidly/become irresponsive.

To address this issue, the messaging channel was split into two (`downloadProgress` and `download${fileid}`) and moved to the individual sub components.