### PR TITLE
refactor: hide components using css

### DIFF
--- a/package.json
+++ b/package.json
@@ -249,6 +249,7 @@
   },
   "dependencies": {
     "adm-zip": "^0.5.1",
+    "classnames": "^2.2.6",
     "dayjs": "^1.9.7",
     "electron-debug": "^3.1.0",
     "electron-log": "^4.2.4",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -2,10 +2,11 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
 import React from 'react';
+import classNames from 'classnames';
 
 const ButtonClassOverride = ({ props, classOverride }) => {
   const { className, ...remainingProps } = props;
-  const newClassName = `${className || ''} ${classOverride}`;
+  const newClassName = classNames(className, classOverride);
   return <button type="button" className={newClassName} {...remainingProps} />;
 };
 

--- a/src/components/DownloadCenter.scss
+++ b/src/components/DownloadCenter.scss
@@ -3,6 +3,10 @@
     float: right;
     margin-right: 3px;
 
+    &.hidden {
+      display: none;
+    }
+
     &.zero {
       opacity: 35%;
     }

--- a/src/components/DownloadCenter.tsx
+++ b/src/components/DownloadCenter.tsx
@@ -2,12 +2,13 @@
 /* eslint-disable promise/catch-or-return */
 import { ipcRenderer } from 'electron';
 import React, { useEffect, useState } from 'react';
+import classNames from 'classnames';
 
 import './DownloadCenter.scss';
 
 const downloads = {};
 
-const DownloadCenter = () => {
+const DownloadCenter = ({ isVisible }) => {
   const [activeDownloadCount, setActiveDownloadCount] = useState(0);
 
   useEffect(() => {
@@ -26,8 +27,13 @@ const DownloadCenter = () => {
     };
   });
 
+  const className = classNames('download-center', {
+    zero: activeDownloadCount === 0,
+    hidden: !isVisible,
+  });
+
   return (
-    <div className={`download-center ${activeDownloadCount === 0 && 'zero'}`}>
+    <div className={className}>
       <div className="download-center-icon" />
       <div className="active-download-count-badge">
         <div className="active-download-count-text">{activeDownloadCount}</div>

--- a/src/components/GlobalFilter.tsx
+++ b/src/components/GlobalFilter.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable react/prop-types */
 import React, { useState } from 'react';
+import classNames from 'classnames';
+
 import { useAsyncDebounce } from 'react-table';
 
-const GlobalFilter = ({ setGlobalFilter, gotoPage, state }) => {
+const GlobalFilter = ({ setGlobalFilter, gotoPage, state, isVisible }) => {
   const { globalFilter } = state;
 
   const [value, setValue] = useState(globalFilter);
@@ -11,8 +13,12 @@ const GlobalFilter = ({ setGlobalFilter, gotoPage, state }) => {
     setGlobalFilter(v || undefined);
   }, 200);
 
+  const className = classNames('globalfilter', {
+    hidden: !isVisible,
+  });
+
   return (
-    <div className="globalfilter">
+    <div className={className}>
       <input
         value={value || ''}
         placeholder="Search..."

--- a/src/components/MainView.scss
+++ b/src/components/MainView.scss
@@ -3,6 +3,10 @@
     float: right;
     margin-bottom: 5px;
 
+    &.hidden {
+      display: none;
+    }
+
     input {
       width: 300px;
       float: right;

--- a/src/components/MainView.tsx
+++ b/src/components/MainView.tsx
@@ -182,21 +182,18 @@ const MainView = ({ library, showAlert }) => {
     return <h2 className="center">Loading...</h2>;
   }
 
-  if (fullscreenComponent) {
-    return (
-      <FullscreenView
-        title={fullscreenComponent.title}
-        content={fullscreenComponent.body}
-        onClose={() => setFullscreenComponent(null)}
-      />
-    );
-  }
-
   return (
     <>
-      <GlobalFilter {...tableInstance} />
-      <DownloadCenter />
-      <TableView tableInstance={tableInstance} />
+      <GlobalFilter {...tableInstance} isVisible={!fullscreenComponent} />
+      <DownloadCenter isVisible={!fullscreenComponent} />
+      {!fullscreenComponent && <TableView tableInstance={tableInstance} />}
+      {fullscreenComponent && (
+        <FullscreenView
+          title={fullscreenComponent.title}
+          content={fullscreenComponent.body}
+          onClose={() => setFullscreenComponent(null)}
+        />
+      )}
     </>
   );
 };

--- a/src/components/MainView.tsx
+++ b/src/components/MainView.tsx
@@ -184,9 +184,6 @@ const MainView = ({ library, showAlert }) => {
 
   return (
     <>
-      <GlobalFilter {...tableInstance} isVisible={!fullscreenComponent} />
-      <DownloadCenter isVisible={!fullscreenComponent} />
-      {!fullscreenComponent && <TableView tableInstance={tableInstance} />}
       {fullscreenComponent && (
         <FullscreenView
           title={fullscreenComponent.title}
@@ -194,6 +191,12 @@ const MainView = ({ library, showAlert }) => {
           onClose={() => setFullscreenComponent(null)}
         />
       )}
+      <GlobalFilter {...tableInstance} isVisible={!fullscreenComponent} />
+      <DownloadCenter isVisible={!fullscreenComponent} />
+      <TableView
+        tableInstance={tableInstance}
+        isVisible={!fullscreenComponent}
+      />
     </>
   );
 };

--- a/src/components/TableView.scss
+++ b/src/components/TableView.scss
@@ -1,5 +1,10 @@
 :global {
   .tableview {
+
+    &.hidden {
+      display: none;
+    }
+
     .table {
 
       td,

--- a/src/components/TableView.tsx
+++ b/src/components/TableView.tsx
@@ -1,13 +1,15 @@
 /* eslint-disable react/jsx-props-no-spreading */
 /* eslint-disable react/jsx-key */
 import React from 'react';
+import classNames from 'classnames';
+
 import PageControl from './PageControl';
 import TableHeaderGroup from './TableHeaderGroup';
 import TableRow from './TableRow';
 
 import './TableView.scss';
 
-const TableView = ({ tableInstance }) => {
+const TableView = ({ tableInstance, isVisible }) => {
   const {
     getTableProps,
     getTableBodyProps,
@@ -15,8 +17,12 @@ const TableView = ({ tableInstance }) => {
     page,
   } = tableInstance;
 
+  const className = classNames('tableview', {
+    hidden: !isVisible,
+  });
+
   return (
-    <div className="tableview">
+    <div className={className}>
       <table className="table" {...getTableProps()}>
         <thead>
           {headerGroups.map((headerGroup: any) => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3307,6 +3307,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"


### PR DESCRIPTION
when `fullscreenComponent` is present in `MainView`, all other subcomponents should be hidden.

Previously, this was achieved by unmounting the other subcomponents from the view. While this works, there is a lot of edge cases to consider with resepct to the components' lifecycle.

Alternatively, the components can stay on the view but be hidden with `isVisible=false` which translates to: `display: none;` in CSS.