### PR TITLE
fix: make the open button render properly

### DIFF
--- a/src/components/FileActions.tsx
+++ b/src/components/FileActions.tsx
@@ -23,7 +23,15 @@ const FileActions = ({
     const downloadListener = (_event, { percentage, isInitial }) => {
       if (isInitial || percentage > download.percentage) {
         download.percentage = percentage;
-        setRerenderTimestamp(Date.now());
+        if (percentage !== 100) {
+          setRerenderTimestamp(Date.now());
+        } else {
+          // If the file is small, the component must have been re-rendering very rapidly.
+          // Give it a little break to ensure the final render happens properly.
+          setTimeout(() => {
+            setRerenderTimestamp(Date.now());
+          }, 100);
+        }
       }
     };
     ipcRenderer.on(channel, downloadListener);
@@ -52,10 +60,10 @@ const FileActions = ({
   };
 
   let actionButton = null;
-  if (download.percentage !== null && download.percentage < 100) {
-    actionButton = <Button disabled>{download.percentage}%</Button>;
-  } else if (existsSync(encryptedPath)) {
+  if (existsSync(encryptedPath)) {
     actionButton = <Button onClick={openInApp}>Open</Button>;
+  } else if (download.percentage !== null) {
+    actionButton = <Button disabled>{download.percentage}%</Button>;
   } else if (locationref) {
     actionButton = (
       <Button onClick={() => ipcRenderer.invoke('download', file)}>


### PR DESCRIPTION
When a small file is being downloaded, it can go from 0% to 100% in a short amount of time -- say, 3 seconds. This means that the state changes 100 times in 3 seconds; causing a few 'blips' in the rendering process.

This is especially problematic when the percentage has reached 100% and the user expects the button to change from '100%' to 'Open'.

This PR gives the component a little break, so the final render happens properly.