### PR TITLE
fix: always display up to date context menu

### DIFF
--- a/src/components/MainView.tsx
+++ b/src/components/MainView.tsx
@@ -1,10 +1,3 @@
-/* eslint-disable promise/catch-or-return */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/interactive-supports-focus */
-/* eslint-disable react/display-name */
-/* eslint-disable react/jsx-key */
-/* eslint-disable react/jsx-props-no-spreading */
-/* eslint-disable react/prop-types */
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   useTable,
@@ -24,7 +17,7 @@ import FullscreenView from './FullscreenView';
 import Filename from './Filename';
 import TableView from './TableView';
 import FileActions from './FileActions';
-import { ipcRenderer } from 'electron';
+import { getLocalActions, getRemoteActions } from '../utils/contextMenuUtils';
 
 const regularColumns = [
   'ispublic',
@@ -84,10 +77,11 @@ const MainView = ({ library, showAlert }) => {
         } else {
           file.dateactivated = Date.now();
         }
-        const newStateStr = dateactivated ? 'unfavorited' : 'favorited';
-        rerender();
-        showAlert(`The file has been ${newStateStr}`);
-      });
+        return dateactivated ? 'unfavorited' : 'favorited';
+      })
+      .then((newValue: string) => showAlert(`The file has been ${newValue}`))
+      .then(rerender())
+      .catch(showAlert);
   };
 
   const renderActions = ({ row }) => {
@@ -181,16 +175,26 @@ const MainView = ({ library, showAlert }) => {
         }
       }
     }
-
-    const downloadListener = (_event, { percentage }) => {
-      if (percentage === 100) rerender();
-    };
-    ipcRenderer.on('downloadProgress', downloadListener);
-
-    return () => {
-      ipcRenderer.removeListener('downloadProgress', downloadListener);
-    };
   }, []);
+
+  const getConextMenuOptions = (inputFile) => {
+    const file =
+      renderBuffer.files.find((f) => f.fileid === inputFile.fileid) ||
+      inputFile;
+    return [
+      ...getLocalActions(file, library, rerender, showAlert),
+      ...getRemoteActions(file, updateFile, rerender, showAlert),
+      {
+        label: 'Show Metadata',
+        onClick: () => {
+          setFullscreenComponent({
+            title: file.filename,
+            body: <pre>{JSON.stringify(file, null, 2)}</pre>,
+          });
+        },
+      },
+    ];
+  };
 
   if (!files) {
     return <h2 className="center">Loading...</h2>;
@@ -210,11 +214,7 @@ const MainView = ({ library, showAlert }) => {
       <TableView
         tableInstance={tableInstance}
         isVisible={!fullscreenComponent}
-        setFullscreenComponent={setFullscreenComponent}
-        updateFile={updateFile}
-        rerenderRowData={rerender}
-        showAlert={showAlert}
-        library={library}
+        getConextMenuOptions={getConextMenuOptions}
       />
     </>
   );

--- a/src/components/TableRow.tsx
+++ b/src/components/TableRow.tsx
@@ -1,39 +1,26 @@
-/* eslint-disable react/jsx-key */
-/* eslint-disable react/jsx-props-no-spreading */
-/* eslint-disable react/prop-types */
-import React from 'react';
-import {
-  getLocalActions,
-  getMetadataOptions,
-  getRemoteActions,
-} from '../utils/contextMenuUtils';
-
+import { ipcRenderer } from 'electron';
+import React, { useEffect, useState } from 'react';
 import ContextMenuWrapper from './ContextMenuWrapper';
 
-const TableRow = ({
-  row,
-  prepareRow,
-  library,
-  setFullscreenComponent,
-  updateFile,
-  rerenderRowData,
-  showAlert,
-}) => {
+const TableRow = ({ row, prepareRow, getConextMenuOptions }) => {
+  const [,setTimestamp] = useState(null);
   prepareRow(row);
 
-  const options = [];
-  options.push(...getLocalActions(row.original, library, rerenderRowData, showAlert));
-  options.push(...getRemoteActions(row.original, updateFile, rerenderRowData, showAlert));
+  const rerender = () => {
+    setTimestamp(Date.now());
+  };
 
-  // Show Metadata is always available.
-  options.push({
-    label: 'Show Metadata',
-    onClick: () => {
-      setFullscreenComponent({
-        title: row.original.filename,
-        body: <pre>{JSON.stringify(row.original, null, 2)}</pre>,
-      });
-    },
+  useEffect(() => {
+    const channel = `download${row.original.fileid}`;
+    const downloadListener = (_event, { percentage }) => {
+      if (percentage === 100) {
+        rerender();
+      }
+    };
+    ipcRenderer.on(channel, downloadListener);
+    return () => {
+      ipcRenderer.removeListener(channel, downloadListener);
+    };
   });
 
   return (
@@ -43,7 +30,7 @@ const TableRow = ({
           <ContextMenuWrapper
             id={row.original.fileid}
             component={cell.render('Cell')}
-            options={options}
+            options={getConextMenuOptions(row.original)}
           />
         </td>
       ))}

--- a/src/components/TableView.tsx
+++ b/src/components/TableView.tsx
@@ -12,17 +12,14 @@ import './TableView.scss';
 const TableView = ({
   tableInstance,
   isVisible,
-  setFullscreenComponent,
-  updateFile,
-  rerenderRowData,
-  showAlert,
-  library,
+  getConextMenuOptions,
 }) => {
   const {
     getTableProps,
     getTableBodyProps,
     headerGroups,
     page,
+    prepareRow,
   } = tableInstance;
 
   const className = classNames('tableview', {
@@ -41,12 +38,8 @@ const TableView = ({
           {page.map((row) => (
             <TableRow
               row={row}
-              setFullscreenComponent={setFullscreenComponent}
-              updateFile={updateFile}
-              showAlert={showAlert}
-              rerenderRowData={rerenderRowData}
-              library={library}
-              {...tableInstance}
+              prepareRow={prepareRow}
+              getConextMenuOptions={getConextMenuOptions}
             />
           ))}
         </tbody>


### PR DESCRIPTION
Introduce a new state prop in `TableRow` component so when the download progress reaches 100% for a given file, it knows to re-render itself.

The `row.original` will still contain old data until the parents have been re-rendered. To get around this problem, `getConextMenuOptions()` was introduced which always tires to find the latest information in `renderBuffer`.