### PR TITLE
feat: display the first decimal place for GB and larger

### DIFF
--- a/src/utils/numberUtils.ts
+++ b/src/utils/numberUtils.ts
@@ -1,8 +1,9 @@
-/* eslint-disable import/prefer-default-export */
+const UNITS = ['B', 'kB', 'MB', 'GB', 'TB', 'PB'];
+
+// eslint-disable-next-line import/prefer-default-export
 export function humanFileSize(sizeInBytes: number) {
   const i = Math.floor(Math.log(sizeInBytes) / Math.log(1024));
   // eslint-disable-next-line no-restricted-properties
-  const value = (sizeInBytes / Math.pow(1024, i)).toFixed(0);
-  const unit = ['B', 'kB', 'MB', 'GB', 'TB'][i];
-  return `${value} ${unit}`;
+  const value = (sizeInBytes / Math.pow(1024, i)).toFixed(i < 3 ? 0 : 1);
+  return `${value} ${UNITS[i]}`;
 }


### PR DESCRIPTION
`humanFileSize` currently returns the whole number. This works well for bytes, kilobytes, and megabytes.

GB and TB are still considered fairly large in today's standards. It's going to be nice to have the first couple of decimal places.