### PR TITLE
feat: ability to specify a temporary path

### DIFF
--- a/src/client/gdrive.ts
+++ b/src/client/gdrive.ts
@@ -1,4 +1,5 @@
 import { renameSync } from 'fs';
+import { createParentPath } from '../utils/fileUtils';
 
 /* eslint-disable import/prefer-default-export */
 const fs = require('fs');
@@ -65,7 +66,7 @@ class GdriveClient {
     });
   }
 
-  async downloadFileAsync(fileId: string, localPath: string, progressCallback) {
+  async downloadFileAsync(fileId: string, localPath: string, tmpLocalPath: string, progressCallback) {
     google.options({ auth: this.getOAuthClient() });
 
     const res = await drive.files.get(
@@ -74,7 +75,7 @@ class GdriveClient {
     );
 
     return new Promise((resolve, reject) => {
-      const tmpLocalPath = `${localPath}.download`;
+      createParentPath(tmpLocalPath);
       const dest = fs.createWriteStream(tmpLocalPath);
       const { data } = res;
       let downloadedBytes = 0;

--- a/src/components/FileActions.tsx
+++ b/src/components/FileActions.tsx
@@ -23,6 +23,7 @@ const FileActions = ({
     filename,
     mimetype,
     encryptedPath,
+    decryptedPath,
   } = file;
   const [download] = useState({ percentage: null });
   const [, setRerenderTimestamp] = useState(null);
@@ -71,6 +72,7 @@ const FileActions = ({
       body: (
         <FileView
           encryptedPath={encryptedPath}
+          decryptedPath={decryptedPath}
           aespassword={aespassword}
           onDetectMimetype={onDetectMimetype}
           contextMenuOptions={contextMenuOptions}

--- a/src/components/FileView.tsx
+++ b/src/components/FileView.tsx
@@ -22,6 +22,7 @@ const getInnermostChild = (el: HTMLElement) => {
 
 type FileViewProps = {
   encryptedPath: string;
+  decryptedPath: string;
   aespassword: string;
   onDetectMimetype: Function;
   contextMenuOptions: ContextMenuOption[];
@@ -29,11 +30,11 @@ type FileViewProps = {
 
 const FileView = ({
   encryptedPath,
+  decryptedPath,
   aespassword,
   onDetectMimetype,
   contextMenuOptions,
 }: FileViewProps) => {
-  const decryptedPath = `${encryptedPath}.dec`;
   const [content, setContent] = useState<HTMLElement | null>(null);
   const contentRef = useRef(null);
 

--- a/src/components/MainView.tsx
+++ b/src/components/MainView.tsx
@@ -198,6 +198,7 @@ const MainView = ({ library, showAlert }) => {
       const progressCallback = (moreFiles) => {
         moreFiles.forEach((file) => {
           file.encryptedPath = library.getEncryptedPath(file.fileid);
+          file.decryptedPath = library.getDecryptedPath(file.fileid);
           file.filename = htmlDecode(file.filename);
         });
         renderBuffer.files = renderBuffer.files.concat(

--- a/src/entity/File.ts
+++ b/src/entity/File.ts
@@ -1,8 +1,15 @@
 export type File = {
+  // Mandatory fields
   fileid: string;
-  storageservice: string | null | undefined;
-  encryptedPath: string;
   sourceurl: string;
-  dateactivated: number | null | undefined;
   lastupdated: number;
+
+  // Optional fields
+  dateactivated?: number;
+  storageservice?: string;
+  locationref?: string;
+  size?: number;
+
+  // Decorative/local fields
+  encryptedPath: string;
 };

--- a/src/entity/Library.ts
+++ b/src/entity/Library.ts
@@ -14,7 +14,13 @@ type LibraryConfig = {
   };
   local: {
     path: string;
+    tmpPath?: string;
   };
+};
+
+const getPath = (parent: string, fileid: string, ext: string) => {
+  const fileidNew = fileid.replace('/', 'slash');
+  return path.join(parent, `${fileidNew}.${ext}`);
 };
 
 class Library {
@@ -35,8 +41,19 @@ class Library {
   }
 
   getEncryptedPath(fileid: string) {
-    const fileidNew = fileid.replace('/', 'slash');
-    return path.join(this.config.local.path, `${fileidNew}.aes`);
+    return getPath(this.config.local.path, fileid, 'aes');
+  }
+
+  getTmpPath() {
+    return this.config.local.tmpPath || this.config.local.path;
+  }
+
+  getDecryptedPath(fileid: string) {
+    return getPath(this.getTmpPath(), fileid, 'dec');
+  }
+
+  getDownloadPath(fileid: string) {
+    return getPath(this.getTmpPath(), fileid, 'download');
   }
 }
 

--- a/src/main.dev.handlers.ts
+++ b/src/main.dev.handlers.ts
@@ -1,45 +1,45 @@
 /* eslint-disable no-console */
 import { ipcMain } from 'electron';
 import { createReadStream, createWriteStream } from 'fs';
+import { File } from './entity/File';
 import { decryptAes256Cbc } from './utils/cryptoUtils';
+import { createParentPath } from './utils/fileUtils';
 
 export const handleDownload = (mainWindow, library, gdriveClient) => {
   ipcMain.removeHandler('download');
-  ipcMain.handle(
-    'download',
-    async (_event, { fileid, storageservice, locationref, size }) => {
-      const respond = (percentage: number, isInitial = false) => {
-        const payload = { fileid, percentage, isInitial };
-        mainWindow?.webContents.send('downloadProgress', payload);
-        mainWindow?.webContents.send(`download${fileid}`, payload);
-      };
+  ipcMain.handle('download', async (_event, file: File) => {
+    const { fileid, storageservice, locationref, size, encryptedPath } = file;
+    const respond = (percentage: number, isInitial = false) => {
+      const payload = { fileid, percentage, isInitial };
+      mainWindow?.webContents.send('downloadProgress', payload);
+      mainWindow?.webContents.send(`download${fileid}`, payload);
+    };
 
-      console.log(`Download event received: ${fileid}`);
-      const localPath = library.getEncryptedPath(fileid);
-      switch (storageservice) {
-        case 'gdrive': {
-          respond(0, true);
-          console.log(`Download started: ${fileid}`);
-          const callback = ({ downloadedBytes }) => {
-            const percentage = Math.floor((downloadedBytes * 100) / size);
-            respond(percentage);
-            if (percentage === 100) {
-              console.log(`Download finished: ${fileid}`);
-            }
-          };
+    console.log(`Download event received: ${fileid}`);
+    switch (storageservice) {
+      case 'gdrive': {
+        respond(0, true);
+        console.log(`Download started: ${fileid}`);
+        const callback = ({ downloadedBytes }) => {
+          const percentage = Math.floor((downloadedBytes * 100) / size);
+          respond(percentage);
+          if (percentage === 100) {
+            console.log(`Download finished: ${fileid}`);
+          }
+        };
 
-          gdriveClient
-            .downloadFileAsync(locationref, localPath, callback)
-            .then(() => respond(100))
-            .catch(console.log);
-          break;
-        }
-        default: {
-          throw new Error(`Unsupported storageservice: ${storageservice}`);
-        }
+        const downloadPath = library.getDownloadPath(fileid);
+        gdriveClient
+          .downloadFileAsync(locationref, encryptedPath, downloadPath, callback)
+          .then(() => respond(100))
+          .catch(console.log);
+        break;
+      }
+      default: {
+        throw new Error(`Unsupported storageservice: ${storageservice}`);
       }
     }
-  );
+  });
 };
 
 export const handleDecrypt = () => {
@@ -47,6 +47,8 @@ export const handleDecrypt = () => {
   ipcMain.handle(
     'decrypt',
     async (_event, { encryptedPath, decryptedPath, aespassword }) => {
+      createParentPath(decryptedPath);
+
       const streamIn = createReadStream(encryptedPath);
       const streamOut = createWriteStream(decryptedPath);
       return decryptAes256Cbc(streamIn, streamOut, aespassword).then(() => {

--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -14,10 +14,11 @@ import path from 'path';
 import { app, BrowserWindow, shell, ipcMain } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
+import { existsSync } from 'fs';
 import MenuBuilder from './menu';
 import GdriveClient from './client/gdrive';
 import Library from './entity/Library';
-import { purgeDecryptedFiles } from './utils/fileUtils';
+import { purgeDecryptedFiles as purgeTmpFiles } from './utils/fileUtils';
 import { handleDecrypt, handleDownload } from './main.dev.handlers';
 
 export default class AppUpdater {
@@ -132,19 +133,16 @@ const createWindow = async () => {
  */
 
 app.on('window-all-closed', () => {
-  if (!library) {
+  const tmpPath = library?.getTmpPath();
+  if (!library || !existsSync(tmpPath)) {
     appQuitWrapper();
     return;
   }
 
-  setTimeout(
-    () =>
-      // Wait 1.5 seconds for files to close gracefully, delete the files and then call .appQuitWrapper().
-      purgeDecryptedFiles(library.config.local.path)
-        .then((results) => results.forEach((result) => console.log(result)))
-        .finally(appQuitWrapper),
-    1500
-  );
+  purgeTmpFiles(tmpPath)
+    .then((results) => results.forEach((result) => console.log(result)))
+    .finally(appQuitWrapper)
+    .catch(alert);
 });
 
 app.whenReady().then(createWindow).catch(console.log);

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -1,4 +1,4 @@
-import { unlink, readdirSync, lstatSync, rmdirSync } from 'fs';
+import { unlink, readdirSync, lstatSync, rmdirSync, existsSync, mkdirSync } from 'fs';
 import { glob } from 'glob';
 
 import FileType from 'file-type';
@@ -60,4 +60,11 @@ export const guessMimetypeAsync = (filepath: string) => {
       // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw MIMETYPE_DETECTION_ERROR;
     });
+};
+
+export const createParentPath = (filepath: string) => {
+  const parentPath = path.dirname(filepath);
+  if (!existsSync(parentPath)) {
+    mkdirSync(parentPath);
+  }
 };


### PR DESCRIPTION
This PR adds the ability to specify a temporary path. The temporary path can be set in the following config property: `local.tmpPath`.

Having this option provides a few benefits:
1. can take advantage of hardware with faster write speeds (ie. storing the encrypted copies in HDD while using a faster SSD as a scratch disk)
2. can better control the disk usage (if the disk with the encrypted files is nearly full, the temporary files can be directed elsewhere)
3. can have a separate purge process without closing the app. The purge action only executes at the end of the app's lifecycle.