### PR TITLE
fix: cross device copy

### DIFF
--- a/src/client/gdrive.ts
+++ b/src/client/gdrive.ts
@@ -1,4 +1,4 @@
-import { renameSync } from 'fs';
+import { copyFileSync, unlinkSync } from 'fs';
 import { createParentPath } from '../utils/fileUtils';
 
 /* eslint-disable import/prefer-default-export */
@@ -94,7 +94,8 @@ class GdriveClient {
           }
         });
         data.on('finish', () => {
-          renameSync(tmpLocalPath, localPath);
+          copyFileSync(tmpLocalPath, localPath);
+          unlinkSync(tmpLocalPath);
           resolve(localPath);
         });
         data.pipe(dest);

--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -18,7 +18,7 @@ import { existsSync } from 'fs';
 import MenuBuilder from './menu';
 import GdriveClient from './client/gdrive';
 import Library from './entity/Library';
-import { purgeDecryptedFiles as purgeTmpFiles } from './utils/fileUtils';
+import { purgeTmpFiles } from './utils/fileUtils';
 import { handleDecrypt, handleDownload } from './main.dev.handlers';
 
 export default class AppUpdater {
@@ -141,8 +141,8 @@ app.on('window-all-closed', () => {
 
   purgeTmpFiles(tmpPath)
     .then((results) => results.forEach((result) => console.log(result)))
-    .finally(appQuitWrapper)
-    .catch(alert);
+    .catch(console.log)
+    .finally(appQuitWrapper);
 });
 
 app.whenReady().then(createWindow).catch(console.log);

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -30,7 +30,7 @@ export const deleteAllAsync = (
     })
   );
 
-export const purgeDecryptedFiles = (dir: string) => {
+export const purgeTmpFiles = (dir: string) => {
   const filenames = readdirSync(dir).filter((f) => !f.endsWith('.aes'));
   return deleteAllAsync(filenames, dir);
 };


### PR DESCRIPTION
With the introduction of `config.local.tmpPath`, user can utilize two devices. For example, an SSD as the scratch disk and an HDD as the long term storage disk.

In such a configuration, the app needs to move files between two devices. `renameSync` is not suitable for this kind of operation, and needed to be replaced with `copyFileSync` and `unlinkSync`.